### PR TITLE
feat: enhance runCommand with exit codes, background execution, and command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const customSandbox = await Sandbox.create("e2b", { template: "my-template-id" }
 // const sandbox = await Sandbox.connect("daytona", "sandbox_id");
 
 // Run commands and interact with the sandbox
-console.log(await sandbox.runCommand("echo 'hello world'"));
+const { output } = await sandbox.runCommand("echo 'hello world'");
+console.log(output);
 console.log(await sandbox.listFiles("/"));
 
 // Suspend, resume and destroy the sandbox
@@ -108,8 +109,24 @@ const sandbox = await Sandbox.connect("daytona", "sandbox_id");
 
 ### runCommand
 
+Execute commands in the sandbox with support for background execution and command options.
+
 ```js
-console.log(await sandbox.runCommand("echo 'hello world'"));
+// Basic command execution
+const { exitCode, output } = await sandbox.runCommand("echo 'hello world'");
+console.log(output); // "hello world"
+console.log(exitCode); // 0
+
+// Command with options
+const result = await sandbox.runCommand("ls -la", {
+  cwd: "/tmp",
+  envs: { MY_VAR: "value" },
+  timeoutMs: 5000
+});
+
+// Background command execution
+const { pid } = await sandbox.runCommand("sleep 10", { background: true });
+console.log(`Background process started with PID: ${pid}`);
 ```
 
 ### suspend
@@ -223,5 +240,4 @@ const sandbox = await Sandbox.create('daytona', { template: 'my-snapshot' });
 ## Future Plans
 
 - Add support for watching file system changes
-- Add support for running commands in the background
 - Add support for running code

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -10,6 +10,13 @@ export interface CreateSandboxOptions {
   envs?: Record<string, string>;
 }
 
+export interface RunCommandOptions {
+  background?: boolean;
+  cwd?: string;
+  envs?: Record<string, string>;
+  timeoutMs?: number;
+}
+
 export abstract class Sandbox {
   // Create a new sandbox instance
   static async create(provider: string, options?: CreateSandboxOptions) {
@@ -35,8 +42,26 @@ export abstract class Sandbox {
   // Create a new sandbox or connect to an existing one
   protected abstract init(id?: string, createOptions?: CreateSandboxOptions): Promise<void>;
 
-  // Execute a command in the sandbox and return its output
-  abstract runCommand(command: string): Promise<string>;
+  /**
+   * Start a new command and wait until it finishes executing.
+   * 
+   * @param command Command to run
+   * @param options Options for running the command
+   */
+  abstract runCommand(
+    command: string,
+    options?: RunCommandOptions & { background?: false }
+  ): Promise<{ exitCode: number; output: string }>;
+  /**
+   * Start a new command in background and return its process ID.
+   * 
+   * @param command Command to run
+   * @param options Options for running the command
+   */
+  abstract runCommand(
+    command: string,
+    options?: RunCommandOptions & { background: true }
+  ): Promise<{ pid: number }>;
 
   // Get the sandbox ID
   abstract id(): string;


### PR DESCRIPTION
## Summary
- Enhanced `runCommand` method across all providers to return exit codes and support background execution
- Added new `RunCommandOptions` interface for better command configuration
- Updated return type from `string` to structured object with exit code, PID and output.
- Added comprehensive tests for new functionality including error handling and background commands

## Key Changes
- **New `RunCommandOptions` interface** with support for:
  - `background`: Run commands in background and return PID
  - `cwd`: Set working directory for command execution
  - `envs`: Pass environment variables to commands
  - `timeoutMs`: Set command timeout

- **Enhanced `runCommand` method** with method overloads:
  - Foreground: Returns `{ exitCode: number; output: string }`
  - Background: Returns `{ pid: number }`

- **Provider implementations updated**:
  - **E2B**: Full native support with proper CommandExitError handling, direct background execution using SDK's background flag, comprehensive error/stdout/stderr output consolidation
  - **Daytona**: Leverages existing `executeCommand` API with full option support (cwd, envs, timeoutMs), background execution via nohup shell wrapper
  - **CodeSandbox**: Uses SDK's `commands.run` with cwd/env support, background execution simulated with nohup wrapper, exit codes retrieved via separate `echo $?` command
  - **Modal**: Uses `sandbox.exec` with shell command wrapping, background execution via nohup, exit codes from process.returncode

- **Test coverage expanded**:
  - Added tests for command failure scenarios (exit code 127)
  - Added tests for background command execution
  - Updated existing tests to handle new return format
  - Enhanced environment variable tests

## Breaking Changes
⚠️ **Breaking Change**: The `runCommand` method now returns an object `{ exitCode, output }` instead of a plain string. Update your code accordingly:

```typescript
// Before
const output = await sandbox.runCommand('echo hello');

// After
const { exitCode, output } = await sandbox.runCommand('echo hello');
```