### PR TITLE
fix: resolve race condition causing empty command output in SSH executeCommand

### DIFF
--- a/src/providers/utils/ssh.ts
+++ b/src/providers/utils/ssh.ts
@@ -81,13 +81,17 @@ export class SSHClient {
           // For foreground commands, collect output and wait for completion
           let output = '';
           let errorOutput = '';
+          let exitCode = 0;
 
           stream
-            .on('exit', (exitCode: number) => {
+            .on('close', () => {
               resolve({ 
                 exitCode: exitCode, 
                 output: output + (errorOutput ? '\nSTDERR:\n' + errorOutput : '')
               });
+            })
+            .on('exit', (code: number) => {
+              exitCode = code || 0;
             })
             .on('data', (data: Buffer) => {
               output += data.toString();


### PR DESCRIPTION

### Problem
The `executeCommand` method was intermittently returning empty output for commands that should produce output (e.g., `echo "Hello"`). This was caused by a race condition where the method was resolving on the `exit` event before all stream data had been fully received.

### Root Cause
- The `exit` event fires when the remote process terminates
- However, stdout/stderr streams may still have buffered data that hasn't been read yet
- This timing issue caused the promise to resolve with incomplete output

### Solution
- **Changed event listener** from `exit` to `close` event for promise resolution
- The `close` event ensures all streams (stdout, stderr) are fully closed and all data received
- **Separated exit code handling** to capture the exit code from the `exit` event and use it when the `close` event fires

### Changes Made
```typescript
// Before: Resolved on 'exit' - could miss buffered stream data
stream.on('exit', (exitCode: number) => {
  resolve({ exitCode, output: ... });
});

// After: Resolve on 'close' - ensures all data is received
stream
  .on('close', () => {
    resolve({ exitCode: exitCode, output: ... });
  })
  .on('exit', (code: number) => {
    exitCode = code || 0; // Capture exit code separately
  });
```

### Testing
- [x] Commands with stderr output work correctly  
- [x] Background commands unaffected
- [x] Exit codes properly captured and returned

### Impact
- **Low risk**: Only changes event handling, no API changes
- **High value**: Fixes intermittent empty output bug that could cause deployment script failures
- **Backward compatible**: No breaking changes to method signatures